### PR TITLE
Change image source for zeppelin

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,7 +77,7 @@ services:
 
   zeppelin:
     #image: incadencecorp/zeppelin-server:0.9.0-SNAPSHOT
-    image: docker-dspc.di2e.net/zeppelin-server:0.9.0-SNAPSHOT
+    image: apache/zeppelin:0.9.0
     container_name: dspc-zeppelin
     volumes:
       - type: bind


### PR DESCRIPTION
Change the image for zeppelin from "docker-dspc.di2e.net/zeppelin-server:0.9.0-SNAPSHOT" to "apache/zeppelin:0.9.0" so that the zeppelin image pulls from a different source and an authentication error does not occur when running docker-compose.